### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   def index
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,7 +21,7 @@ class Item < ApplicationRecord
     validates :price
   end
 
-  with_options numericality: { other_than: 1 , message: 'Select'}  do
+  with_options numericality: { other_than: 1, message: 'Select' } do
     validates :category_id
     validates :condition_id
     validates :fee_id

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -119,24 +119,31 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br>
+            <% if item.fee_id == 2 %>
+              着払い(購入者負担)
+            <% elsif item.fee_id == 3 %>
+              送料込み(出品者負担)
+            <% end %>
+            </span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -145,6 +152,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -118,45 +118,43 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
+        <li class='list'>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-            <div class='sold-out'>
-              <span>Sold Out!!</span>
-            </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+            <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+            <%# //商品が売れていればsold outを表示しましょう %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= item.name %>
-          </h3>
-          <div class='item-price'>
-            <span><%= item.price %>円<br>
-            <% if item.fee_id == 2 %>
-              着払い(購入者負担)
-            <% elsif item.fee_id == 3 %>
-              送料込み(出品者負担)
-            <% end %>
-            </span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          </div>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br>
+              <% if item.fee_id == 2 %>
+                着払い(購入者負担)
+              <% elsif item.fee_id == 3 %>
+                送料込み(出品者負担)
+              <% end %>
+              </span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items = nil %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,12 +172,13 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+      <% end %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>
   <%# /商品一覧 %>
 </div>
+
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>
     <% if user_signed_in? %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -154,7 +154,7 @@
       <% end %>
 
       <%# 商品がない場合のダミー %>
-      <% if @items = nil %>
+      <% if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -87,7 +87,7 @@ describe Item do
         expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
       it '価格の値が範囲外(上限)だと出品できない' do
-        @item.price = 100000000
+        @item.price = 100_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price Out of setting range')
       end


### PR DESCRIPTION
#What
商品一覧表示機能
#Why
出品された商品はトップページに一覧で表示させる

商品一覧表示
https://gyazo.com/6038cdb5183bcde77b21cd9e8a3300ee
画像からのリンク
https://gyazo.com/696becaac90913e15a76e20a2600715c
商品の表示順
https://gyazo.com/b2ccad757a57f323d562a10021573d06
ログアウト状態でも商品を見ることができる
https://gyazo.com/4c36314fa0c4db113c9491cb53f679d9


購入機能未達のため「sold out」の表示未達